### PR TITLE
fixes to get it to compile

### DIFF
--- a/shared/scene/Scene.h
+++ b/shared/scene/Scene.h
@@ -1,5 +1,6 @@
 ﻿#pragma once
 
+#include <string>
 #include <unordered_map>
 #include <vector>
 

--- a/shared/vkRenderers/UtilsVulkanQuadRenderer.h
+++ b/shared/vkRenderers/UtilsVulkanQuadRenderer.h
@@ -2,6 +2,8 @@
 
 #include "shared/vkRenderers/UtilsVulkanRendererBase.h"
 
+#include <string>
+#include <stdio.h>
 #include <glm/glm.hpp>
 #include <glm/ext.hpp>
 using glm::mat4;

--- a/shared/vkRenderers/UtilsVulkanRendererBase.cpp
+++ b/shared/vkRenderers/UtilsVulkanRendererBase.cpp
@@ -1,4 +1,5 @@
 #include "shared/vkRenderers/UtilsVulkanRendererBase.h"
+#include <stdio.h>
 
 RendererBase::~RendererBase()
 {

--- a/shared/vkRenderers/UtilsVulkanSingleQuad.cpp
+++ b/shared/vkRenderers/UtilsVulkanSingleQuad.cpp
@@ -1,4 +1,5 @@
 #include "shared/vkRenderers/UtilsVulkanSingleQuad.h"
+#include <stdio.h>
 
 bool VulkanSingleQuadRenderer::createDescriptorSet(VulkanRenderDevice& vkDev, VkImageLayout desiredLayout)
 {


### PR DESCRIPTION
**This PR fixes compile errors when building on Ubuntu.**

Building on Ubuntu using default compiler settings

1. git clone
2. mkdir build/ && cd build/ && cmake ..
3. make

This PR fixes all the errors - just missing includes - but does not address any warnings.

**Testing**

* Ran a random selection of demos after successful compile and all worked, but...
* Please also note that binaries are not placed relative to the data paths they try to load when built in this manner (using a build/ subdir, which is pretty standard). This may be confusing for some readers. I had to move them manually to the root folder, which is kind of tedious, but then they work. If the CMake was set up to dump all the binaries into one folder it would be easier to move them about so they are relative to `data/`.
* I have some feedback about chapter 8 code on my machine I will email.

