### PR TITLE
Bugfix/texture fallback

### DIFF
--- a/shared/glFramework/GLTexture.cpp
+++ b/shared/glFramework/GLTexture.cpp
@@ -30,6 +30,23 @@ GLTexture::GLTexture(GLenum type, int width, int height, GLenum internalFormat)
 	glTextureStorage2D(handle_, getNumMipMapLevels2D(width, height), internalFormat, width, height);
 }
 
+/// Draw a checkerboard on a pre-allocated square RGB or RGBA image.
+static void _gen_checkerboard_img( uint8_t* img_ptr, int w, int h, int n )
+{
+  assert( img_ptr && w > 0 && h > 0 && n > 0 );
+  assert( w == h && ( n == 3 || n == 4 ) );
+  if ( !img_ptr || w <= 0 || h <= 0 || n <= 0 ) { return; }
+  if ( w != h || ( n != 3 && n != 4 ) ) { return; }
+
+  for ( int i = 0; i < w * h; i++ )
+  {
+    int row            = i / w;
+    int col            = i % w;
+    img_ptr[i * n + 0] = img_ptr[i * n + 1] = img_ptr[i * n + 2] = 0xFF * ( ( row + col ) % 2 );
+    if ( n > 3 ) { img_ptr[i * n + 3] = 0xFF; }
+  }
+}
+
 GLTexture::GLTexture(GLenum type, const char* fileName)
 	: type_(type)
 {
@@ -64,8 +81,23 @@ GLTexture::GLTexture(GLenum type, const char* fileName)
 		}
 		else
 		{
-			const uint8_t* img = stbi_load(fileName, &w, &h, nullptr, STBI_rgb_alpha);
-			assert(img);
+			uint8_t* img = stbi_load(fileName, &w, &h, nullptr, STBI_rgb_alpha);
+      
+      // Note(Anton): replaced assert( img ) with a fallback image to prevent crashes with missing files or bad (eg very long) paths.
+      if ( !img )
+      {
+        fprintf( stderr, "WARNING: could not load image `%s`, using a fallback.\n", fileName );
+        w = 128;
+        h = 128;
+        img = (uint8_t*)malloc( w * h * 4 );
+        if ( !img )
+        {
+          fprintf( stderr, "FATAL ERROR: Out of memory allocating image for fallback texture\n" );
+          abort();
+        }
+        _gen_checkerboard_img( img, w, h, 4 ) ;
+      }
+
 			numMipmaps = getNumMipMapLevels2D(w, h);
 			glTextureStorage2D(handle_, numMipmaps, GL_RGBA8, w, h);
 			glTextureSubImage2D(handle_, 0, 0, 0, w, h, GL_RGBA, GL_UNSIGNED_BYTE, img);

--- a/shared/glFramework/GLTexture.cpp
+++ b/shared/glFramework/GLTexture.cpp
@@ -33,18 +33,18 @@ GLTexture::GLTexture(GLenum type, int width, int height, GLenum internalFormat)
 /// Draw a checkerboard on a pre-allocated square RGB or RGBA image.
 static void _gen_checkerboard_img( uint8_t* img_ptr, int w, int h, int n )
 {
-  assert( img_ptr && w > 0 && h > 0 && n > 0 );
-  assert( w == h && ( n == 3 || n == 4 ) );
-  if ( !img_ptr || w <= 0 || h <= 0 || n <= 0 ) { return; }
-  if ( w != h || ( n != 3 && n != 4 ) ) { return; }
+	assert( img_ptr && w > 0 && h > 0 && n > 0 );
+	assert( w == h && ( n == 3 || n == 4 ) );
+	if ( !img_ptr || w <= 0 || h <= 0 || n <= 0 ) { return; }
+	if ( w != h || ( n != 3 && n != 4 ) ) { return; }
 
-  for ( int i = 0; i < w * h; i++ )
-  {
-    int row            = i / w;
-    int col            = i % w;
-    img_ptr[i * n + 0] = img_ptr[i * n + 1] = img_ptr[i * n + 2] = 0xFF * ( ( row + col ) % 2 );
-    if ( n > 3 ) { img_ptr[i * n + 3] = 0xFF; }
-  }
+	for ( int i = 0; i < w * h; i++ )
+	{
+		int row            = i / w;
+		int col            = i % w;
+		img_ptr[i * n + 0] = img_ptr[i * n + 1] = img_ptr[i * n + 2] = 0xFF * ( ( row + col ) % 2 );
+		if ( n > 3 ) { img_ptr[i * n + 3] = 0xFF; }
+	}
 }
 
 GLTexture::GLTexture(GLenum type, const char* fileName)
@@ -82,21 +82,21 @@ GLTexture::GLTexture(GLenum type, const char* fileName)
 		else
 		{
 			uint8_t* img = stbi_load(fileName, &w, &h, nullptr, STBI_rgb_alpha);
-      
-      // Note(Anton): replaced assert( img ) with a fallback image to prevent crashes with missing files or bad (eg very long) paths.
-      if ( !img )
-      {
-        fprintf( stderr, "WARNING: could not load image `%s`, using a fallback.\n", fileName );
-        w = 128;
-        h = 128;
-        img = (uint8_t*)malloc( w * h * 4 );
-        if ( !img )
-        {
-          fprintf( stderr, "FATAL ERROR: Out of memory allocating image for fallback texture\n" );
-          abort();
-        }
-        _gen_checkerboard_img( img, w, h, 4 ) ;
-      }
+			
+			// Note(Anton): replaced assert( img ) with a fallback image to prevent crashes with missing files or bad (eg very long) paths.
+			if ( !img )
+			{
+				fprintf( stderr, "WARNING: could not load image `%s`, using a fallback.\n", fileName );
+				w = 128;
+				h = 128;
+				img = (uint8_t*)malloc( w * h * 4 );
+				if ( !img )
+				{
+					fprintf( stderr, "FATAL ERROR: Out of memory allocating image for fallback texture\n" );
+					abort();
+				}
+				_gen_checkerboard_img( img, w, h, 4 ) ;
+			}
 
 			numMipmaps = getNumMipMapLevels2D(w, h);
 			glTextureStorage2D(handle_, numMipmaps, GL_RGBA8, w, h);


### PR DESCRIPTION
This PR addresses an abort that can happen when running demos using the _Bistro_ data.

* Full file paths for some very long texture names could exceed OS maximum of 255 bytes, e.g. a full system path to `... /3D-Graphics-Rendering-Cookbook/data/out_textures/deps__src__bistro__exterior______proptextures__street__paris_bistroexteriorspotlight_01__paris_bistroexteriorspotlight_01_diff.png__rescaled.png` can exceed 255 bytes in UTF-8.
* Those files would not be written during the Bistro data conversion step (a Chapter 7 demo), and subsequently not able to be loaded in Chapter 10 demos.

* This PR does not prevent very long filenames being created.
* In the event that any texture asset is missing, a checkerboard image is created in its place and used instead.
* This may be helpful to diagnose other texture file and path issues that arise with reader set-ups.
* A warning message is printed to `stderr` to help users diagnose the problem.
* The previous `assert( img )` was removed, but since this also had the virtue of checking for memory allocation issues, a separate memory allocation check is added here, with an error message and a similar `abort()`.

* Example of output, where missing textures produce a warning, and are recovered from:

```
anton:~/projects/3D-Graphics-Rendering-Cookbook[master]$ ./Ch10_SampleGL01_CullingCPU 
WARNING: could not load image `data/out_textures/deps__src__bistro__exterior______proptextures__street__paris_bistroexteriorspotlight_01__paris_bistroexteriorspotlight_01_diff.png__rescaled.png`, using a fallback.
WARNING: could not load image `data/out_textures/deps__src__bistro__exterior______proptextures__street__paris_bistroexteriorspotlight_01__paris_bistroexteriorspotlightglass_01_diff.png__rescaled.png`, using a fallback.
```

## Testing

* Tested all of the Chapter 10 demos on Ubuntu, and a random selection of the other demos to make sure there was no regression introduced. I was able to move around the scene and interact/view correctly the demos that were not loading before.
* I have not testing this on Windows.


