### PR TITLE
Fix Validation Error in Chapter 4 Vulkan Demo App

### DIFF
--- a/shared/UtilsVulkan.cpp
+++ b/shared/UtilsVulkan.cpp
@@ -306,7 +306,8 @@ VkResult createDevice(VkPhysicalDevice physicalDevice, VkPhysicalDeviceFeatures 
 {
 	const std::vector<const char*> extensions =
 	{
-		VK_KHR_SWAPCHAIN_EXTENSION_NAME
+		VK_KHR_SWAPCHAIN_EXTENSION_NAME,
+		VK_KHR_SHADER_DRAW_PARAMETERS_EXTENSION_NAME
 	};
 
 	const float queuePriority = 1.0f;


### PR DESCRIPTION
Hello, 
This is a small fix that I applied to my fork to solve the following validation error reported in `Ch4_SampleVk01_DemoApp`. 
```
Validation layer: Validation Error: [ VUID-VkShaderModuleCreateInfo-pCode-01091 ] Object 0: handle = 0x1b5fb056e80, type = VK_OBJECT_TYPE_DEVICE; | MessageID = 0xa7bb8db6 | vkCreateShaderModule(): The SPIR-V Capability (DrawParameters) was declared, but none of the requirements were met to use it. The Vulkan spec states: If pCode declares any of the capabilities listed in the SPIR-V Environment appendix, one of the corresponding requirements must be satisfied (https://vulkan.lunarg.com/doc/view/1.3.211.0/windows/1.3-extensions/vkspec.html#VUID-VkShaderModuleCreateInfo-pCode-01091)
Debug callback (Validation): Validation Error: [ VUID-VkShaderModuleCreateInfo-pCode-01091 ] Object 0: handle = 0x1b5fb056e80, type = VK_OBJECT_TYPE_DEVICE; | MessageID = 0xa7bb8db6 | vkCreateShaderModule(): The SPIR-V Capability (DrawParameters) was declared, but none of the requirements were met to use it. The Vulkan spec states: If pCode declares any of the capabilities listed in the SPIR-V Environment appendix, one of the corresponding requirements must be satisfied (https://vulkan.lunarg.com/doc/view/1.3.211.0/windows/1.3-extensions/vkspec.html#VUID-VkShaderModuleCreateInfo-pCode-01091)
```
Adding `VK_KHR_SHADER_DRAW_PARAMETERS_EXTENSION_NAME` to the device extensions fixes this error for me. 