### PR TITLE
Fix an issue where the frame index goes out of boundaries.

### DIFF
--- a/Chapter6/VK02_DescriptorIndexing/src/main.cpp
+++ b/Chapter6/VK02_DescriptorIndexing/src/main.cpp
@@ -33,7 +33,7 @@ void updateAnimations()
 	for (size_t i = 0; i < animations.size();)
 	{
 		animations[i].textureIndex = animations[i].flipbookOffset + (uint32_t)(kAnimationFPS * ((glfwGetTime() - animations[i].startTime)));
-		if (animations[i].textureIndex - animations[i].flipbookOffset > kNumFlipbookFrames)
+		if (animations[i].textureIndex - animations[i].flipbookOffset > (kNumFlipbookFrames - 1))
 			animations.erase(animations.begin() + i);
 		else
 			i++;


### PR DESCRIPTION
Fix an issue where the frame index goes out of boundaries.
Which caused a VK_ERROR_DEVICE_LOST in vkDeviceWaitIdle.
Example: index starts at 200 and ends up with 300, it is 101 frames, and the last one, 300, doesn't exist and leads to runtime error, I think because of undefined behavior.
