### PR TITLE
Fix an issue where camera position isn't used in grid calculation

### DIFF
--- a/data/shaders/chapter05/GL01_grid.frag
+++ b/data/shaders/chapter05/GL01_grid.frag
@@ -5,9 +5,10 @@
 #include <data/shaders/chapter05/GridCalculation.h>
 
 layout (location=0) in vec2 uv;
+layout (location=1) in vec2 camPos;
 layout (location=0) out vec4 out_FragColor;
 
 void main()
 {
-	out_FragColor = gridColor(uv);
+	out_FragColor = gridColor(uv, camPos);
 };

--- a/data/shaders/chapter05/GL01_grid.vert
+++ b/data/shaders/chapter05/GL01_grid.vert
@@ -5,6 +5,7 @@
 #include <data/shaders/chapter05/GridParameters.h>
 
 layout (location=0) out vec2 uv;
+layout (location=1) out vec2 out_camPos;
 
 void main()
 {
@@ -12,6 +13,11 @@ void main()
 
 	int idx = indices[gl_VertexID];
 	vec3 position = pos[idx] * gridSize;
+	
+	position.x += cameraPos.x;
+	position.z += cameraPos.z;
+
+	out_camPos = cameraPos.xz;
 
 	gl_Position = MVP * vec4(position, 1.0);
 	uv = position.xz;

--- a/data/shaders/chapter05/GridCalculation.h
+++ b/data/shaders/chapter05/GridCalculation.h
@@ -18,7 +18,7 @@ float max2(vec2 v)
 	return max(v.x, v.y);
 }
 
-vec4 gridColor(vec2 uv)
+vec4 gridColor(vec2 uv, vec2 camPos)
 {
 	vec2 dudv = vec2(
 		length(vec2(dFdx(uv.x), dFdy(uv.x))),
@@ -40,6 +40,8 @@ vec4 gridColor(vec2 uv)
 	float lod0a = max2( vec2(1.0) - abs(satv(mod(uv, lod0) / dudv) * 2.0 - vec2(1.0)) );
 	float lod1a = max2( vec2(1.0) - abs(satv(mod(uv, lod1) / dudv) * 2.0 - vec2(1.0)) );
 	float lod2a = max2( vec2(1.0) - abs(satv(mod(uv, lod2) / dudv) * 2.0 - vec2(1.0)) );
+
+	uv -= camPos;
 
 	// blend between falloff colors to handle LOD transition
 	vec4 c = lod2a > 0.0 ? gridColorThick : lod1a > 0.0 ? mix(gridColorThick, gridColorThin, lodFade) : gridColorThin;

--- a/data/shaders/chapter07/VK03_InfinitePlane.frag
+++ b/data/shaders/chapter07/VK03_InfinitePlane.frag
@@ -5,9 +5,10 @@
 #include <data/shaders/chapter05/GridCalculation.h>
 
 layout (location=0) in vec2 uv;
+layout (location=1) in vec2 cameraPos;
 layout (location=0) out vec4 out_FragColor;
 
 void main()
 {
-	out_FragColor = gridColor(uv);
+	out_FragColor = gridColor(uv, cameraPos);
 }

--- a/data/shaders/chapter07/VK03_InfinitePlane.vert
+++ b/data/shaders/chapter07/VK03_InfinitePlane.vert
@@ -4,6 +4,7 @@
 #include <data/shaders/chapter05/GridParameters.h>
 
 layout (location=0) out vec2 uv;
+layout (location=1) out vec2 cameraPos;
 
 layout(binding = 0) uniform  UniformBuffer
 {
@@ -19,6 +20,12 @@ void main()
 
 	int idx = indices[gl_VertexIndex];
 	vec3 position = pos[idx] * gridSize;
+
+	mat4 iview = inverse(ubo.view);
+	cameraPos = vec2(iview[3][0], iview[3][2]);
+
+	position.x += cameraPos.x;
+	position.z += cameraPos.y;
 
 	gl_Position = MVP * vec4(position, 1.0);
 	uv = position.xz;


### PR DESCRIPTION
The camera position was missed from the grid calculation, so the grid always stuck in the origin.