### PR TITLE
Fix UtilsCubemap compilation error in Ubuntu 22.04

### DIFF
--- a/shared/UtilsCubemap.cpp
+++ b/shared/UtilsCubemap.cpp
@@ -1,6 +1,7 @@
 ﻿#include "UtilsMath.h"
 #include "UtilsCubemap.h"
 
+#include <cstdio>
 #include <glm/glm.hpp>
 #include <glm/ext.hpp>
 


### PR DESCRIPTION
I just added a single missing `#include <cstdio>` for a `printf` in `shared/UtilsCubemap.cpp`: it now correctly builds on Ubuntu 22.04.