### PR TITLE
Use the correct structure to initialize resources

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -135,7 +135,9 @@ set_property(TARGET SPVRemapper   PROPERTY FOLDER "ThirdPartyLibraries/glslang")
 # shared utils code for GL and Vulkan
 add_subdirectory(shared)
 
-target_sources(SharedUtils PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/deps/src/glslang/StandAlone/ResourceLimits.cpp)
+target_sources(SharedUtils PRIVATE 
+    ${CMAKE_CURRENT_SOURCE_DIR}/deps/src/glslang/StandAlone/ResourceLimits.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/deps/src/glslang/StandAlone/resource_limits_c.cpp)
 
 add_subdirectory(Chapter1/2_CMake)
 

--- a/shared/UtilsVulkan.cpp
+++ b/shared/UtilsVulkan.cpp
@@ -170,7 +170,7 @@ static size_t compileShader(glslang_stage_t stage, const char* shaderSource, Sha
 		.force_default_version_and_profile = false,
 		.forward_compatible = false,
 		.messages = GLSLANG_MSG_DEFAULT_BIT,
-		.resource = (const glslang_resource_t*)&glslang::DefaultTBuiltInResource,
+		.resource = glslang_default_resource(),
 	};
 
 	glslang_shader_t* shader = glslang_shader_create(&input);

--- a/shared/UtilsVulkan.h
+++ b/shared/UtilsVulkan.h
@@ -8,6 +8,7 @@
 #include <volk/volk.h>
 
 #include "glslang_c_interface.h"
+#include "resource_limits_c.h"
 
 #define VK_CHECK(value) CHECK(value == VK_SUCCESS, __FILE__, __LINE__);
 #define VK_CHECK_RET(value) if ( value != VK_SUCCESS ) { CHECK(false, __FILE__, __LINE__); return value; }


### PR DESCRIPTION
It's better not to rely on the identity of the glslang_resource_t and TBuiltInResource structures.
For C-API it's better to use ```glslang_default_resource()``` function. For real production code the library ```glslang-default-resource-limits``` should be linked too.