### PR TITLE
Center anti-aliased lines

### DIFF
--- a/data/shaders/chapter05/GridCalculation.h
+++ b/data/shaders/chapter05/GridCalculation.h
@@ -36,6 +36,9 @@ vec4 gridColor(vec2 uv, vec2 camPos)
 	// each anti-aliased line covers up to 4 pixels
 	dudv *= 4.0;
 
+	// Update grid coordinates for subsequent alpha calculations (centers each anti-aliased line)
+  	uv = uv + dudv / 2.0F;
+
 	// calculate absolute distances to cell line centers for each lod and pick max X/Y to get coverage alpha value
 	float lod0a = max2( vec2(1.0) - abs(satv(mod(uv, lod0) / dudv) * 2.0 - vec2(1.0)) );
 	float lod1a = max2( vec2(1.0) - abs(satv(mod(uv, lod1) / dudv) * 2.0 - vec2(1.0)) );

--- a/data/shaders/chapter05/GridCalculation.h
+++ b/data/shaders/chapter05/GridCalculation.h
@@ -37,7 +37,7 @@ vec4 gridColor(vec2 uv, vec2 camPos)
 	dudv *= 4.0;
 
 	// Update grid coordinates for subsequent alpha calculations (centers each anti-aliased line)
-  	uv = uv + dudv / 2.0F;
+  	uv += dudv / 2.0F;
 
 	// calculate absolute distances to cell line centers for each lod and pick max X/Y to get coverage alpha value
 	float lod0a = max2( vec2(1.0) - abs(satv(mod(uv, lod0) / dudv) * 2.0 - vec2(1.0)) );


### PR DESCRIPTION
I've noticed that introducing anti-aliasing (`dudv *= 4.0;`) results in grid lines that aren't centered with the world grid line location.  As a visual, here is a cube aligned with a world grid line:

  - Current grid:
    - <img width="361" alt="issue" src="https://github.com/PacktPublishing/3D-Graphics-Rendering-Cookbook/assets/142453833/4bb32047-cd3b-43fa-9fb6-30dc5774711d">


  - Increased anti-aliasing to show issue (`dudv *= 40`):
    - <img width="258" alt="orig" src="https://github.com/PacktPublishing/3D-Graphics-Rendering-Cookbook/assets/142453833/17496e95-3e8b-41dd-b7de-eb3c2eb61ac7">


  - Applying fix:  
    - <img width="297" alt="fixed" src="https://github.com/PacktPublishing/3D-Graphics-Rendering-Cookbook/assets/142453833/38a5029d-7cb3-4376-a91a-fba1d5150b2d">

This portion of the code gets to be fairly abstract.  I believe the issue is due to the subsequent alpha calculations being offset by dudv, which has been modified 4x in the positive x and z directions.  This leads to anti-aliased lines starting in correct position but setting their darkest portion at an offset.  The fix above changes the alpha calculations to start at an offset, resulting in the darkest portion of the gridlines aligning with the world line centers.

I'd also welcome the authors opinion on the offset issue as well to help my own understanding of the issue.
