### PR TITLE
Fix endsWith()

### DIFF
--- a/shared/Utils.cpp
+++ b/shared/Utils.cpp
@@ -32,9 +32,13 @@ void printShaderSource(const char* text)
 	printf("\n");
 }
 
-int endsWith(const char* s, const char* part)
+bool endsWith(const char* s, const char* part)
 {
-	return (strstr( s, part ) - s) == (strlen( s ) - strlen( part ));
+	const size_t sLength = strlen(s);
+	const size_t partLength = strlen(part);
+	if (sLength < partLength)
+		return false;
+	return strcmp(s + sLength - partLength, part) == 0;
 }
 
 std::string readShaderFile(const char* fileName)

--- a/shared/Utils.h
+++ b/shared/Utils.h
@@ -10,7 +10,7 @@
 #include <string>
 #include <vector>
 
-int endsWith(const char* s, const char* part);
+bool endsWith(const char* s, const char* part);
 
 std::string readShaderFile(const char* fileName);
 


### PR DESCRIPTION
Current implementation of `endsWith` is wrong, since `strstr` finds the first match, not the last. To demonstrate:
```
endsWith("ba", "a"); // returns 1
endsWith("aa", "a"); // returns 0
```

This PR contains one possible fix, feel free to use something else.

Also, thanks for the awesome book!