### PR TITLE
[CRASH]Fix crash issue

### DIFF
--- a/data/shaders/chapter05/GL02_duck.geom
+++ b/data/shaders/chapter05/GL02_duck.geom
@@ -2,6 +2,9 @@
 #version 460 core
 
 layout( triangles ) in;
+
+in gl_PerVertex{vec4 gl_Position;}gl_in[];
+
 layout( triangle_strip, max_vertices = 3 ) out;
 
 layout (location=0) in vec2 uv[];

--- a/data/shaders/chapter05/GL02_duck.vert
+++ b/data/shaders/chapter05/GL02_duck.vert
@@ -35,6 +35,8 @@ vec2 getTexCoord(int i)
 	return vec2(in_Vertices[i].tc[0], in_Vertices[i].tc[1]);
 }
 
+out gl_PerVertex{vec4 gl_Position;};
+
 layout (location=0) out vec2 uv_in;
 layout (location=1) out vec3 worldPos_in;
 


### PR DESCRIPTION
- GLSL requires that every stage that redeclares gl_PerVertex must redeclare it with an identical member list (same fields, same order, same arrayness) or else the linker fails with “definitions of interface block 'gl_PerVertex' do not match"

I get an error: definitions of interface block `gl_PerVertex' do not match
Ch5_SampleGL02_Tessellation_Debug: /3D-Graphics-Rendering-Cookbook/shared/glFramework/GLShader.cpp:45: void printProgramInfoLog(GLuint): Assertion `false' failed.
Aborted (core dumped)